### PR TITLE
rpi3/qemu: Pass raspi3b as machine name to Qemu.

### DIFF
--- a/board/rpi3/qemu_args
+++ b/board/rpi3/qemu_args
@@ -1,1 +1,1 @@
--M raspi3 -m 1024
+-M raspi3b -m 1024


### PR DESCRIPTION
The old raspi3 machine name has been deprecated in qemu since commit
155e1c82ed0da265dbc6cd499a2b2552a5388a9c "docs/system: Deprecate
raspi2/raspi3 machine aliases". The aliases for old names have then been
removed in 57469ed384b1f83788f0f1995af673b735f4f790 "hw/arm/raspi:
Remove deprecated raspi2/raspi3 aliases". This means that Genode
RPI3 port can no longer be booted on Qemu 6.2.0 due to unrecognized
machine name.

Switch to raspi3b machine name which works with current Qemu versions.