### PR TITLE
Change rspi3 machine type

### DIFF
--- a/board/rpi3/qemu_args
+++ b/board/rpi3/qemu_args
@@ -1,1 +1,1 @@
--M raspi3 -m 1024
+-M raspi3b -m 1024


### PR DESCRIPTION
The machine type raspi3 is no longer recognized by qemu.

The qemu version:

```bash
# qemu-system-aarch64 --version
QEMU emulator version 6.2.0 (Debian 1:6.2+dfsg-2ubuntu6.6) 
Copyright (c) 2003-2021 Fabrice Bellard and the QEMU Project developers
```